### PR TITLE
prevent loading of model pickle files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 .pyre/.DS_Store
 =======
 .pyre/
+
+# ignore pickle files
+*.pkl
+**/.pkl


### PR DESCRIPTION
I don't want the local pickle files that are created to be uploaded to the repo.